### PR TITLE
fix: replace vue builtin type hints with uni

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@dcloudio/uni-cli-shared": "3.0.0-3080720230703001",
     "@dcloudio/uni-stacktracey": "3.0.0-3080720230703001",
     "@dcloudio/vite-plugin-uni": "3.0.0-3080720230703001",
+    "@uni-helper/uni-app-types": "^0.5.12",
     "@uni-helper/uni-ui-types": "^0.5.11",
     "@uni-helper/vite-plugin-uni-components": "^0.0.6",
     "@uni-helper/vite-plugin-uni-manifest": "^0.2.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,12 @@
       "dom"
     ],
     "types": [
-      "@dcloudio/types"
+      "@dcloudio/types",
+      "@uni-helper/uni-app-types"
     ]
+  },
+  "vueCompilerOptions": {
+    "nativeTags": ["block", "component", "template", "slot"]
   },
   "include": [
     "src/**/*.ts",


### PR DESCRIPTION
![image](https://github.com/xkfe/uni-vscode-template/assets/65693818/782c1566-c0de-489e-9248-0332c9c5dd90)
标签button被识别成Vue内置Button类型，修复为uniapp的Button类型